### PR TITLE
fix

### DIFF
--- a/chrome/build/style.css
+++ b/chrome/build/style.css
@@ -20,7 +20,7 @@ font-family: Helvetica, Arial, sans-serif;
 background-color: white;
 z-Index: 16777271;
 box-shadow:-15px 0 50px rgba(0,0,0,0.15);
-overflow: scroll;
+overflow-y: scroll;
 }
 
 /****************************************************

--- a/chrome/src/shadow.css
+++ b/chrome/src/shadow.css
@@ -151,6 +151,10 @@
   transform: scale (1);
 }
 
+.chromelights-btn:focus {
+  outline: none;
+}
+
 .chromelights-entry {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
prevents  Chrome's default button outline when a button is clicked